### PR TITLE
 #5: Add Docker image for Manifold MCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json /app/package.json
+COPY package-lock.json /app/package-lock.json 
+COPY src/ /app/src
+COPY tsconfig.json /app/tsconfig.json
+
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+RUN npm run build
+
+FROM node:22-alpine AS release
+
+COPY --from=builder /app/build /app/build
+COPY --from=builder /app/package.json /app/package.json
+COPY --from=builder /app/node_modules /app/node_modules/
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+ENTRYPOINT ["node", "build/index.js"]

--- a/README.md
+++ b/README.md
@@ -74,8 +74,15 @@ These operations are implemented but require specific user roles:
 
 ## Prerequisites
 
+### NodeJS Installation
 - Node.js 18 or higher
 - npm or yarn
+- Manifold Markets API key
+- Minimum M$1000 balance for market creation
+
+### Docker Installation
+- Docker Engine v1.12.0 or greater (included with
+[Docker Desktop](https://www.docker.com/products/docker-desktop/) installation
 - Manifold Markets API key
 - Minimum M$1000 balance for market creation
 
@@ -83,8 +90,17 @@ These operations are implemented but require specific user roles:
 
 ### 1. Install the package
 
+**NodeJS Installation:**
+
 ```bash
 npm install manifold-mcp-server
+```
+
+**Docker Installation:**
+
+```bash
+docker pull ghcr.io/tiovikram/manifold-mcp-server
+docker tag ghcr.io/tiovikram/manifold-mcp-server manifold-mcp-server
 ```
 
 ### 2. Get your API Key
@@ -95,6 +111,8 @@ npm install manifold-mcp-server
 4. Ensure account has sufficient mana for intended operations
 
 ### 3. Configure MCP Settings
+
+**NodeJS Installation:**
 
 #### For Claude Desktop
 
@@ -124,6 +142,58 @@ Add to `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude
     "manifold": {
       "command": "node",
       "args": ["/path/to/manifold-mcp-server/build/index.js"],
+      "env": {
+        "MANIFOLD_API_KEY": "your_api_key_here"
+      }
+    }
+  }
+}
+```
+
+**Docker Installation:**
+
+#### For Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "manifold": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "MANIFOLD_API_KEY",
+        "manifold-mcp-server"
+      ],
+      "env": {
+        "MANIFOLD_API_KEY": "your_api_key_here"
+      }
+    }
+  }
+}
+```
+
+#### For Cline (VSCode Extension)
+
+Add to `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "manifold": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "MANIFOLD_API_KEY",
+        "manifold-mcp-server"
+      ],
       "env": {
         "MANIFOLD_API_KEY": "your_api_key_here"
       }


### PR DESCRIPTION
  * Add Dockerfile to build Manifold MCP Docker image
  * Update README.md with Docker installation instructions
  ---
  ## What
Manifold Markets MCP requires the installation of Node JS

## Why
Users that may not have node installed or want to wrangle node installation paths to run the MCP may want to use the Manifold Markets MCP. Running the MCP locally through Node has also been finicky for MCP users using other MCPs.

## How
Create a docker image of the MCP that users can run the Manifold Markets MCP through

## Task Items
1. Add Dockerfile that permits building the Manifold Markets MCP as a Docker image to the repository
2. Push the Docker image to a publicly accessible container registry so that users may download and use the Docker image
3. Update section **[3. Configure MCP Settings](https://github.com/bmorphism/manifold-mcp-server?tab=readme-ov-file#3-configure-mcp-settings)** in repository [README.md](https://github.com/bmorphism/manifold-mcp-server/blob/main/README.md) with the following instructions to run the MCP via Docker

```bash
docker pull <DOCKER_REGISTRY_NAME>/<MANIFOLD_MCP_DOCKER_IMAGE_NAME>:latest
```

```json
{
  "mcpServers": {
    "manifold": {
      "command": "docker",
      "args": [
        "run",
        "--rm",
        "-i",
        "-e",
        "MANIFOLD_API_KEY",
        "<MANIFOLD_MCP_LOCAL_DOCKER_IMAGE_NAME>"
      ],
      "env": {
        "MANIFOLD_API_KEY": "your_api_key_here"
      }
    }
  }
}
```